### PR TITLE
Encode html characters before displaying them

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -373,6 +373,10 @@ function showError(msg) {
     errorBox.text(msg);
 }
 
+function htmlEncode(value){
+  return $('<div/>').text(value).html();
+}
+
 function renderQuery(query) {
     var dataBox = $("#data");
     var thead = dataBox.find("thead").find("tr");
@@ -411,7 +415,7 @@ function renderQuery(query) {
         var tr = $('<tr>');
         var s = sel.get();
         for (var i = 0; i < s.length; i++) {
-            tr.append('<td><span title="' + s[i] + '">' + s[i] + '</span></td>');
+            tr.append('<td><span title="' + htmlEncode(s[i]) + '">' + htmlEncode(s[i]) + '</span></td>');
         }
         tbody.append(tr);
     }


### PR DESCRIPTION
I've added this to prevent scripts from executing and html inside the database from rendering.
Currently, if you have any scripts inside a database they would execute and not display properly.